### PR TITLE
relative import of prometheus_wrapper

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -25,7 +25,7 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.exceptions import TransportError
-from prometheus_wrapper import PrometheusWrapper
+from .prometheus_wrapper import PrometheusWrapper
 
 from . import kibana
 from .kibana_discover import generate_kibana_discover_url


### PR DESCRIPTION
Hi, @nicholasgibson2! Please, take a look. I'm not sure about this import, but at least it fixes the error i get when elastalert installed as a package.
`
Traceback (most recent call last):
  File "/usr/local/bin/elastalert", line 11, in <module>
    load_entry_point('elastalert==0.2.1', 'console_scripts', 'elastalert')()
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.6/site-packages/elastalert-0.2.1-py3.6.egg/elastalert/elastalert.py", line 28, in <module>
    from prometheus_wrapper import PrometheusWrapper
ModuleNotFoundError: No module named 'prometheus_wrapper'
`